### PR TITLE
Added support to specify an override path

### DIFF
--- a/kyruus-sdk.js
+++ b/kyruus-sdk.js
@@ -293,25 +293,30 @@ class Kyruus {
 	 * @function getPath
 	 * @summary Does a generic search with the parameters provided if any
 	 * @param {string} [searchString=''] searchString - encoded filter string to send to Kyruus
+	 * @param {string} [path=''] path - path to be appended to the root query path
+	 * @param {string} [override=''] override - optional override parameter to override rootQueryPath + path
 	 * @return {Promise.<KyruusProviderSearch>|*}
 	 */
-	getPath(searchString = '', path = 'providers') {
-		return this.__rootQueryPath() + path + (searchString.length ? (searchString.charAt(0) === '?' ? searchString : '?' + searchString ) : '');
+	getPath(searchString = '', path = 'providers', override = '') {
+		const base = override ? override : this.__rootQueryPath() + path;
+		return base + (searchString.length ? (searchString.charAt(0) === '?' ? searchString : '?' + searchString ) : '');
 	}
 
 	/**
 	 * @function search
 	 * @summary Does a generic search with the parameters provided if any
 	 * @param {string} [searchString=''] searchString - encoded filter string to send to Kyruus
+	 * @param {string} [path=''] path - path to be appended to the root query path
+	 * @param {string} [override=''] override - optional override parameter to override rootQueryPath + path
 	 * @return {Promise.<KyruusProviderSearch>|*}
 	 */
-	search(searchString = '', path = 'providers') {
+	search(searchString = '', path = 'providers', override = '') {
 		if(typeof(searchString) !== 'string' ) {
 			searchString = `${searchString}`;
 		}
 		let options = {
 			hostname: this.endpoint,
-			path: this.getPath(searchString, path)
+			path: this.getPath(searchString, path, override)
 		};
 		return this._refreshToken().then(() => this._https(this._generateDefaultOptions(options)));
 	}

--- a/package.json
+++ b/package.json
@@ -15,28 +15,23 @@
     "node": "6.x.x",
     "npm": "3.x.x"
   },
-
   "repository": {
-     "type": "git",
-     "url": "https://github.com/Asymmetrik/kyruus-node-sdk.git"
+    "type": "git",
+    "url": "https://github.com/Asymmetrik/kyruus-node-sdk.git"
   },
-
   "keywords": [
     "kyruus",
     "rest",
     "api"
   ],
-
   "main": "kyruus-sdk.js",
   "scripts": {
     "mocha": "mocha",
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec"
   },
-
   "peerDependencies": {
     "lodash": "4.x"
   },
-
   "devDependencies": {
     "chai": "^1.10.0",
     "chai-as-promised": "^4.1.1",

--- a/test/kyruus.spec.js
+++ b/test/kyruus.spec.js
@@ -18,7 +18,6 @@ describe('Kyruus SDK', () => {
             kyruuuuuus(q.reject('Bad Request'));
 
             return Kyruus._refreshToken().then((result) => {
-                console.log(result);
                 return q.reject('It logged in');
             }, (err) => {
                 return q.resolve(err);
@@ -29,6 +28,28 @@ describe('Kyruus SDK', () => {
             kyruuuuuus(q({expires_in: 3600}));
             return Kyruus._refreshToken();
         });
+    });
+    
+    describe('getPath', () => {
+      
+      it('should allow for an override path to be specified', () => {
+        const searchString = '';
+        const path = '';
+        const override = '/my/imaginary/root/path';
+        
+        const result = Kyruus.getPath(searchString, path, override);
+        should(result).equal(override);
+      });
+      
+      it('should default to the rootQueryPath + path if no override is specified', () => {
+        const searchString = '?foo';
+        const path = 'providers';
+        const expected = `${Kyruus.__rootQueryPath()}${path}${searchString}`;
+        
+        const result = Kyruus.getPath(searchString, path);
+        should(result).equal(expected);
+      });
+      
     });
 
     describe('Kyruus SDK logged in tests', () => {


### PR DESCRIPTION
This adds the ability to override the root path used in the query on a per query basis to support other Kyruus API's. It is referencing issue #8 . Usage would look like so:

```javascript
const KyruusSDK = require('@asymmetrik/kyruus-node-sdk');
const kyruus = new KyruusSDK(env.KYRUUS_ENDPOINT, env.KYRUUS_SOURCE, env.KYRUUS_USER, env.KYRUUS_PASSWORD);

const query = kyruus.query()
  .param('provider_id', 123456);

kyruus.search(`${query}`, '', '/availability/v2/get/${env.KYRUUS_SOURCE}')
  .then(...)
```
