### PR TITLE
Allow Node 8 and NPM 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,31 +12,26 @@
   "version": "0.1.1",
   "readme": "README.md",
   "engines": {
-    "node": "8.x.x",
-    "npm": "5.x.x"
+    "node": ">=6.x.x <8.x.x",
+    "npm": ">=3.x.x <5.x.x"
   },
-
   "repository": {
-     "type": "git",
-     "url": "https://github.com/Asymmetrik/kyruus-node-sdk.git"
+    "type": "git",
+    "url": "https://github.com/Asymmetrik/kyruus-node-sdk.git"
   },
-
   "keywords": [
     "kyruus",
     "rest",
     "api"
   ],
-
   "main": "kyruus-sdk.js",
   "scripts": {
     "mocha": "mocha",
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec"
   },
-
   "peerDependencies": {
     "lodash": "4.x"
   },
-
   "devDependencies": {
     "chai": "^1.10.0",
     "chai-as-promised": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "version": "0.1.1",
   "readme": "README.md",
   "engines": {
-    "node": "6.x.x",
-    "npm": "3.x.x"
+    "node": "8.x.x",
+    "npm": "5.x.x"
   },
 
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "version": "0.1.1",
   "readme": "README.md",
   "engines": {
-    "node": ">=6.x.x <8.x.x",
-    "npm": ">=3.x.x <5.x.x"
+    "node": ">=6.x.x <=8.x.x",
+    "npm": ">=3.x.x <=5.x.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updated package.json to allow the SDK to run on Node 8 and NPM 5.